### PR TITLE
SCS-334   RN: Create a new transferExecuted event

### DIFF
--- a/packages/link/src/utils/event-types.ts
+++ b/packages/link/src/utils/event-types.ts
@@ -45,6 +45,7 @@ const LINK_EVENT_TYPE_KEYS = [
   'transferMfaRequired',
   'transferMfaEntered',
   'transferKycRequired',
+  'transferExecuted',
   'done',
   'close'
 ] as const


### PR DESCRIPTION
Added the `transferExecuted` to event-types to let SDK fire the event to client-side