### PR TITLE
DEVOPS-323 Adding db caching to trivy flow

### DIFF
--- a/.github/actions/vuln-scan/action.yml
+++ b/.github/actions/vuln-scan/action.yml
@@ -33,7 +33,6 @@ runs:
         scan-type: 'rootfs'
         scan-ref: ${{ inputs.src-dir }}
         trivy-config: trivy.yaml
-        cache-dir: .trivy
     - name: Publish Trivy Output To Summary
       shell: bash
       if: ${{ steps.trivy.outcome == 'failure' }}

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,3 +1,5 @@
+cache:
+    dir: .trivy
 config: trivy.yaml
 exit-code: 1
 format: table


### PR DESCRIPTION
Adding trivy db cache.
Config file cache flag is [nested](https://aquasecurity.github.io/trivy/v0.55/docs/references/configuration/config-file/)
[Jira](https://front-finance.atlassian.net/browse/DEVOPS-323)
[FrontBackEnd change](https://github.com/FrontFin/FrontBackEnd/pull/5173)


[First Run](https://github.com/FrontFin/mesh-web-sdk/actions/runs/10929882352/job/30341568196?pr=37) - creates the cache key
[Second Run](https://github.com/FrontFin/mesh-web-sdk/actions/runs/10929882352/job/30341812608) - Does not. Uses the cache value from first run.