### PR TITLE
Fix session summary typo

### DIFF
--- a/packages/link/src/utils/event-types.ts
+++ b/packages/link/src/utils/event-types.ts
@@ -232,12 +232,12 @@ export interface TransferKycRequired extends LinkEventBase {
 
 export interface DoneEvent extends LinkEventBase {
   type: 'done'
-  payload: SessionSummary
+  payload: SessionSymmary
 }
 
 export interface CloseEvent extends LinkEventBase {
   type: 'close'
-  payload: SessionSummary
+  payload: SessionSymmary
 }
 
 export interface WalletMessageSigned extends LinkEventBase {
@@ -259,7 +259,7 @@ export interface VerifyWalletRejected extends LinkEventBase {
   type: 'verifyWalletRejected'
 }
 
-export interface SessionSummary {
+export interface SessionSymmary {
   /**
    *   Current page of application. Possible values:
    * `startPage`

--- a/packages/link/src/utils/event-types.ts
+++ b/packages/link/src/utils/event-types.ts
@@ -232,12 +232,12 @@ export interface TransferKycRequired extends LinkEventBase {
 
 export interface DoneEvent extends LinkEventBase {
   type: 'done'
-  payload: SessionSymmary
+  payload: SessionSummary
 }
 
 export interface CloseEvent extends LinkEventBase {
   type: 'close'
-  payload: SessionSymmary
+  payload: SessionSummary
 }
 
 export interface WalletMessageSigned extends LinkEventBase {
@@ -259,7 +259,7 @@ export interface VerifyWalletRejected extends LinkEventBase {
   type: 'verifyWalletRejected'
 }
 
-export interface SessionSymmary {
+export interface SessionSummary {
   /**
    *   Current page of application. Possible values:
    * `startPage`

--- a/packages/link/src/utils/types.ts
+++ b/packages/link/src/utils/types.ts
@@ -1,5 +1,5 @@
 import type { BrokerType } from '@meshconnect/node-api'
-import { SessionSymmary, LinkEventType } from './event-types'
+import { SessionSummary, LinkEventType } from './event-types'
 
 export type EventType =
   | 'brokerageAccountAccessToken'
@@ -147,7 +147,7 @@ export interface LinkOptions {
   /**
    * (Optional) A callback function that is called when the Front iframe is closed.
    */
-  onExit?: (error?: string, summary?: SessionSymmary) => void
+  onExit?: (error?: string, summary?: SessionSummary) => void
 
   /**
    * (Optional) A callback function that is called when a transfer is finished.

--- a/packages/link/src/utils/types.ts
+++ b/packages/link/src/utils/types.ts
@@ -1,5 +1,5 @@
 import type { BrokerType } from '@meshconnect/node-api'
-import { SessionSummary, LinkEventType } from './event-types'
+import { SessionSymmary, LinkEventType } from './event-types'
 
 export type EventType =
   | 'brokerageAccountAccessToken'
@@ -147,7 +147,7 @@ export interface LinkOptions {
   /**
    * (Optional) A callback function that is called when the Front iframe is closed.
    */
-  onExit?: (error?: string, summary?: SessionSummary) => void
+  onExit?: (error?: string, summary?: SessionSymmary) => void
 
   /**
    * (Optional) A callback function that is called when a transfer is finished.


### PR DESCRIPTION
Fix session summary typo:
`SessionSymmary` --> `SessionSummary`