### PR TITLE
XPR-1522 fix XSS vulnerability

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -46,6 +46,21 @@ describe('createLink tests', () => {
     expect(iframeElement).toBeFalsy()
   })
 
+  test('createLink when invalid link url provided should not open popup', () => {
+    const exitFunction = jest.fn<void, [string | undefined]>()
+    const frontConnection = createLink({
+      clientId: 'test',
+      onIntegrationConnected: jest.fn(),
+      onExit: exitFunction
+    })
+
+    frontConnection.openLink('amF2YXNjcmlwdDphbGVydChkb2N1bWVudC5kb21haW4pLy8=')
+
+    expect(exitFunction).toHaveBeenCalledWith('Invalid link token!')
+    const iframeElement = document.getElementById('mesh-link-popup__iframe')
+    expect(iframeElement).toBeFalsy()
+  })
+
   test('createLink when valid link provided should open popup', () => {
     const frontConnection = createLink({
       clientId: 'test',

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -446,6 +446,13 @@ export const createLink = (options: LinkOptions): Link => {
 
     currentOptions = options
     let linkUrl = window.atob(linkToken)
+    const isProtocolValid =
+      linkUrl.startsWith('http://') || linkUrl.startsWith('https://')
+    if (!isProtocolValid) {
+      options?.onExit?.('Invalid link token!')
+      return
+    }
+
     linkUrl = addLanguage(linkUrl, currentOptions?.language)
     linkTokenOrigin = new URL(linkUrl).origin
     window.removeEventListener('message', eventsListener)


### PR DESCRIPTION
This pull request updates the `@meshconnect/web-link-sdk` package to version 3.3.2 and introduces improved validation for link tokens in the `createLink` function. The main focus is on preventing popups from opening when an invalid link token is provided, and ensuring that the user is notified appropriately.

Validation and error handling improvements:

* Added a protocol check in `createLink` (`Link.ts`) to ensure the decoded link token starts with `http://` or `https://`. If not, the `onExit` callback is triggered with an error message and the popup is not opened.

Testing enhancements:

* Added a new test in `Link.test.ts` to verify that an invalid link token does not open a popup and calls the `onExit` callback with the correct error message.

Version update:

* Bumped the package version in `package.json` from 3.3.1 to 3.3.2 to reflect these changes.