### PR TITLE
ONC-2762: Update bridge parent to 1.3.0 (parent origin support)

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@meshconnect/node-api": "^2.0.24",
-    "@meshconnect/uwc-bridge-parent": "1.2.1"
+    "@meshconnect/uwc-bridge-parent": "1.3.0"
   },
   "scripts": {
     "build": "yarn updateVersion && rimraf dist && yarn build:esm && yarn copy",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,10 +1508,10 @@
     rpc-websockets "^9.0.2"
     superstruct "^2.0.2"
 
-"@meshconnect/uwc-bridge-parent@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.2.1.tgz#8e44e504f595e1cc4a5bd0d7186d634319881243"
-  integrity sha512-KBJ7UnDT3sBuDElF2Cg45RyGMiFuM1BRjeGyvIoqmTIULDI4kAevVqCCL79YCWqatlStMINFXrA+G0mx9WMJqw==
+"@meshconnect/uwc-bridge-parent@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.3.0.tgz#30b361d907ef9649f84f57b45766c2d1fe26a9d3"
+  integrity sha512-ip2qkGpELabCy4tmMp/8yh6vYEL/YjoCSRDObvjAWjpVgAsK52Tq+mt0cCTpgkyDGbx2aGxhkTSMSRLGll9AJA==
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.23"
     "@solana/wallet-standard-wallet-adapter-base" "^1.1.4"


### PR DESCRIPTION
## Summary
* Bump `@meshconnect/uwc-bridge-parent` from `1.2.1` to `1.3.0` (adds `parentOrigin` for TON manifest URL resolution)
* Bump `web-link-sdk` version from `3.8.1` to `3.9.0`

## Backward compatibility
All changes are purely additive — no existing methods or properties were modified.

| Scenario | Result |
|---|---|
| Old parent (1.2.1) + New child (1.3.0) | Child reads `parentOrigin` via optional chaining → undefined → try-catch fallback → no-op |
| New parent (1.3.0) + Old child (1.2.1) | Parent exposes `parentOrigin`, old child never reads it |
| Both new | Full functionality — child reads parent origin for TON manifest URL resolution |

## After merge
1. Create tag `3.9.0` on the merge commit
2. Create GitHub Release from the tag
3. Trigger **"B2B Web SDK - Test & Deploy Link"** workflow **from the `3.9.0` tag** (not `main`)