### PR TITLE
ONC-2793: Update bridge parent to 1.3.1 (TON iframe fix)

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@meshconnect/node-api": "^2.0.24",
-    "@meshconnect/uwc-bridge-parent": "1.3.0"
+    "@meshconnect/uwc-bridge-parent": "1.3.1"
   },
   "scripts": {
     "build": "yarn updateVersion && rimraf dist && yarn build:esm && yarn copy",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,10 +1508,10 @@
     rpc-websockets "^9.0.2"
     superstruct "^2.0.2"
 
-"@meshconnect/uwc-bridge-parent@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.3.0.tgz#30b361d907ef9649f84f57b45766c2d1fe26a9d3"
-  integrity sha512-ip2qkGpELabCy4tmMp/8yh6vYEL/YjoCSRDObvjAWjpVgAsK52Tq+mt0cCTpgkyDGbx2aGxhkTSMSRLGll9AJA==
+"@meshconnect/uwc-bridge-parent@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.3.1.tgz#ac2d8c525ce9026d3fc1329bd99da4f3e6a42ace"
+  integrity sha512-6SBosxE6SRkZtZB0e1WVw8V5+ni3vgPIe79VrWoT4By+3HcA2/Wz6NKNj6fjYMzBq74JCAGM4jzAsjloDtJVhQ==
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.23"
     "@solana/wallet-standard-wallet-adapter-base" "^1.1.4"


### PR DESCRIPTION
## Summary
- Bump `@meshconnect/uwc-bridge-parent` from `1.3.0` to `1.3.1`
- Bump `web-link-sdk` version from `3.9.0` to `3.9.1`
- Fixes TON Connect in iframe/SDK mode — Trust Wallet was blocking with `dapp.frames-disallowed`

## What changed in bridge-parent 1.3.1
- BridgeParent now proxies the full `InjectedWalletApi` interface (`walletInfo`, `protocolVersion`, `isWalletBrowser`, `restoreConnection`)
- `listen()` return value (unsubscribe function) is wrapped with `Comlink.proxy()` so it can cross postMessage
