### PR TITLE
fix: guard window origin for SSR

### DIFF
--- a/packages/link/src/Link.ssr.test.ts
+++ b/packages/link/src/Link.ssr.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+
+jest.mock('./utils/prewarm', () => ({
+  createPrewarmIframe: jest.fn(),
+  removePrewarmIframe: jest.fn()
+}))
+
+describe('Link SSR safety', () => {
+  test('imports Link module without window and does not prewarm', () => {
+    expect(() => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('./Link')
+      })
+    }).not.toThrow()
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const prewarm = require('./utils/prewarm')
+    expect(prewarm.createPrewarmIframe).not.toHaveBeenCalled()
+  })
+})
+

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -227,6 +227,9 @@ function addTheme(linkUrl: string, theme: LinkOptions['theme']) {
   return linkUrl
 }
 
-if (!window.meshLinkShouldSkipPrewarm) {
+if (
+  typeof window !== 'undefined' &&
+  !window.meshLinkShouldSkipPrewarm
+) {
   createPrewarmIframe()
 }

--- a/packages/link/src/utils/sdk-specs.ts
+++ b/packages/link/src/utils/sdk-specs.ts
@@ -1,7 +1,9 @@
 import { sdkVersion } from './version'
 
+const origin = typeof window !== 'undefined' ? window.location.origin : undefined
+
 export const sdkSpecs = {
   platform: 'web',
   version: sdkVersion,
-  origin: window.location.origin
+  origin
 }

--- a/packages/link/src/utils/style.test.ts
+++ b/packages/link/src/utils/style.test.ts
@@ -10,7 +10,19 @@ describe('Test style utils', () => {
   test('verify function returns nothing on missing query param', () => {
     const link = 'https://some.domain?other=12'
     const received = getLinkStyle(link)
-    expect(received).toBeNull()
+    expect(received).toBeUndefined()
+  })
+
+  test('verify function returns nothing when atob is unavailable', () => {
+    const link = 'https://some.domain?link_style=eyJpciI6IDI0LCAiaW8iOiAwLjF9'
+    const originalAtob = global.atob
+    // @ts-expect-error testing runtime fallback when atob is unavailable
+    global.atob = undefined
+
+    const received = getLinkStyle(link)
+    expect(received).toBeUndefined()
+
+    global.atob = originalAtob
   })
 
   test('verify function returns nothing on wrong encoded value', () => {

--- a/packages/link/src/utils/style.ts
+++ b/packages/link/src/utils/style.ts
@@ -4,7 +4,10 @@ export function getLinkStyle(url: string): LinkStyle | undefined {
   try {
     const params = new URLSearchParams(new URL(url).search)
     const style = params.get('link_style')
-    return style && JSON.parse(window.atob(style))
+    if (!style) return undefined
+
+    if (typeof atob === 'undefined') return undefined
+    return JSON.parse(atob(style))
   } catch (e) {
     return undefined
   }


### PR DESCRIPTION
 ## Summary
  Fixes an SSR/runtime crash in `mesh-web-sdk` Link utilities by removing unconditional access to
  `window.location.origin` at module initialization time.

  ## Behavior Impact
  - Updated `packages/link/src/utils/sdk-specs.ts` to guard browser-only global access:
    - `origin` is now computed with `typeof window !== 'undefined'`.
  - In browser environments, behavior is unchanged (`origin` remains `window.location.origin`).
  - In SSR/non-browser environments, module import no longer throws due to missing `window`; `origin` is
  now `undefined`.