### PR TITLE
PRG-2394 revert

### DIFF
--- a/.github/workflows/mesh.b2b.deploy.link.yml
+++ b/.github/workflows/mesh.b2b.deploy.link.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      # Yarn v1 defaults to registry.yarnpkg.com; align with setup-node / npm publish
-      - run: yarn config set registry https://registry.npmjs.org/
       - run: yarn
       - run: cd packages/link && yarn publish:npm
         env:

--- a/.github/workflows/mesh.b2b.deploy.node.api.yml
+++ b/.github/workflows/mesh.b2b.deploy.node.api.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      # Yarn v1 defaults to registry.yarnpkg.com; align with setup-node / npm publish
-      - run: yarn config set registry https://registry.npmjs.org/
       - run: yarn
       - run: cd packages/node-api && yarn publish:npm
         env:

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -26,7 +26,7 @@
     "util": "^0.12.4"
   },
   "dependencies": {
-    "@meshconnect/node-api": "^2.0.24",
+    "@meshconnect/node-api": "^2.0.25",
     "@meshconnect/uwc-bridge-parent": "1.3.1"
   },
   "scripts": {


### PR DESCRIPTION
- reverts https://github.com/FrontFin/mesh-web-sdk/pull/158
The original problem was with expired npm publish token.

- bump `node-api` to the latest