### PR TITLE
MD-425 Add userId and clientTransactionId to TransferFinishedPayload …

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -1,9 +1,5 @@
 import { createLink } from './Link'
-import {
-  DoneEvent,
-  LinkEventType,
-  TransferExecuted
-} from './utils/event-types'
+import { DoneEvent, LinkEventType, TransferExecuted } from './utils/event-types'
 import { createPrewarmIframe, removePrewarmIframe } from './utils/prewarm'
 import {
   AccessTokenPayload,

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -250,105 +250,9 @@ describe('createLink tests', () => {
     })
   })
 
-  test('createLink "transferFinished" event should send transfer payload', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const onTransferFinishedHandler = jest.fn<void, [TransferFinishedPayload]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: jest.fn(),
-      onEvent: onEventHandler,
-      onTransferFinished: onTransferFinishedHandler
-    })
-
-    frontConnection.openLink(BASE64_ENCODED_URL)
-
-    const payload: TransferFinishedPayload = {
-      status: 'success',
-      txId: 'tid',
-      fromAddress: 'fa',
-      toAddress: 'ta',
-      symbol: 'BTC',
-      amount: 0.001,
-      networkId: 'nid',
-      userId: 'uid',
-      clientTransactionId: 'ctid',
-      amountInFiat: 9.77,
-      totalAmountInFiat: 10.02,
-      networkName: 'Bitcoin',
-      txHash: 'txHash',
-      transferId: 'trid'
-    }
-    window.dispatchEvent(
-      new MessageEvent<EventPayload>('message', {
-        data: {
-          type: 'transferFinished',
-          payload: payload
-        },
-        origin: 'http://localhost'
-      })
-    )
-
-    expect(onEventHandler).toHaveBeenCalledWith({
-      type: 'transferCompleted',
-      payload: payload
-    })
-    expect(onTransferFinishedHandler).toHaveBeenCalledWith(payload)
-  })
-
-  test('createLink "transferFinished" event without userId or clientTransactionId should still send transfer payload', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const onTransferFinishedHandler = jest.fn<void, [TransferFinishedPayload]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: jest.fn(),
-      onEvent: onEventHandler,
-      onTransferFinished: onTransferFinishedHandler
-    })
-
-    frontConnection.openLink(BASE64_ENCODED_URL)
-
-    const payload: TransferFinishedPayload = {
-      status: 'success',
-      txId: 'tid',
-      fromAddress: 'fa',
-      toAddress: 'ta',
-      symbol: 'BTC',
-      amount: 0.001,
-      networkId: 'nid'
-    }
-    window.dispatchEvent(
-      new MessageEvent<EventPayload>('message', {
-        data: {
-          type: 'transferFinished',
-          payload: payload
-        },
-        origin: 'http://localhost'
-      })
-    )
-
-    expect(onEventHandler).toHaveBeenCalledWith({
-      type: 'transferCompleted',
-      payload: payload
-    })
-    expect(onTransferFinishedHandler).toHaveBeenCalledWith(payload)
-    expect(onTransferFinishedHandler.mock.calls[0][0].userId).toBeUndefined()
-    expect(
-      onTransferFinishedHandler.mock.calls[0][0].clientTransactionId
-    ).toBeUndefined()
-  })
-
-  test('createLink "transferExecuted" event forwards userId and clientTransactionId via onEvent', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: jest.fn(),
-      onEvent: onEventHandler
-    })
-
-    frontConnection.openLink(BASE64_ENCODED_URL)
-
-    const event: TransferExecuted = {
-      type: 'transferExecuted',
+  test.each<{ name: string; payload: TransferFinishedPayload }>([
+    {
+      name: 'with all fields',
       payload: {
         status: 'success',
         txId: 'tid',
@@ -358,31 +262,16 @@ describe('createLink tests', () => {
         amount: 0.001,
         networkId: 'nid',
         userId: 'uid',
-        clientTransactionId: 'ctid'
+        clientTransactionId: 'ctid',
+        amountInFiat: 9.77,
+        totalAmountInFiat: 10.02,
+        networkName: 'Bitcoin',
+        txHash: 'txHash',
+        transferId: 'trid'
       }
-    }
-    window.dispatchEvent(
-      new MessageEvent<LinkEventType>('message', {
-        data: event,
-        origin: 'http://localhost'
-      })
-    )
-
-    expect(onEventHandler).toHaveBeenCalledWith(event)
-  })
-
-  test('createLink "transferExecuted" event without userId or clientTransactionId still forwards via onEvent', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: jest.fn(),
-      onEvent: onEventHandler
-    })
-
-    frontConnection.openLink(BASE64_ENCODED_URL)
-
-    const event: TransferExecuted = {
-      type: 'transferExecuted',
+    },
+    {
+      name: 'without userId or clientTransactionId',
       payload: {
         status: 'success',
         txId: 'tid',
@@ -393,18 +282,79 @@ describe('createLink tests', () => {
         networkId: 'nid'
       }
     }
-    window.dispatchEvent(
-      new MessageEvent<LinkEventType>('message', {
-        data: event,
-        origin: 'http://localhost'
+  ])(
+    'createLink "transferFinished" event $name should send transfer payload',
+    ({ payload }) => {
+      const onEventHandler = jest.fn<void, [LinkEventType]>()
+      const onTransferFinishedHandler = jest.fn<
+        void,
+        [TransferFinishedPayload]
+      >()
+      const frontConnection = createLink({
+        clientId: 'test',
+        onIntegrationConnected: jest.fn(),
+        onEvent: onEventHandler,
+        onTransferFinished: onTransferFinishedHandler
       })
-    )
 
-    expect(onEventHandler).toHaveBeenCalledWith(event)
-    const forwarded = onEventHandler.mock.calls[0][0] as TransferExecuted
-    expect(forwarded.payload.userId).toBeUndefined()
-    expect(forwarded.payload.clientTransactionId).toBeUndefined()
-  })
+      frontConnection.openLink(BASE64_ENCODED_URL)
+
+      window.dispatchEvent(
+        new MessageEvent<EventPayload>('message', {
+          data: { type: 'transferFinished', payload: payload },
+          origin: 'http://localhost'
+        })
+      )
+
+      expect(onEventHandler).toHaveBeenCalledWith({
+        type: 'transferCompleted',
+        payload: payload
+      })
+      expect(onTransferFinishedHandler).toHaveBeenCalledWith(payload)
+    }
+  )
+
+  test.each([
+    {
+      name: 'with userId and clientTransactionId',
+      extra: { userId: 'uid', clientTransactionId: 'ctid' }
+    },
+    { name: 'without userId or clientTransactionId', extra: {} }
+  ])(
+    'createLink "transferExecuted" event $name forwards via onEvent',
+    ({ extra }) => {
+      const onEventHandler = jest.fn<void, [LinkEventType]>()
+      const frontConnection = createLink({
+        clientId: 'test',
+        onIntegrationConnected: jest.fn(),
+        onEvent: onEventHandler
+      })
+
+      frontConnection.openLink(BASE64_ENCODED_URL)
+
+      const event: TransferExecuted = {
+        type: 'transferExecuted',
+        payload: {
+          status: 'success',
+          txId: 'tid',
+          fromAddress: 'fa',
+          toAddress: 'ta',
+          symbol: 'BTC',
+          amount: 0.001,
+          networkId: 'nid',
+          ...extra
+        }
+      }
+      window.dispatchEvent(
+        new MessageEvent<LinkEventType>('message', {
+          data: event,
+          origin: 'http://localhost'
+        })
+      )
+
+      expect(onEventHandler).toHaveBeenCalledWith(event)
+    }
+  )
 
   test('createLink "loaded" event should trigger the passing for tokens', () => {
     const tokens: IntegrationAccessToken[] = [

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -1,5 +1,9 @@
 import { createLink } from './Link'
-import { DoneEvent, LinkEventType } from './utils/event-types'
+import {
+  DoneEvent,
+  LinkEventType,
+  TransferExecuted
+} from './utils/event-types'
 import { createPrewarmIframe, removePrewarmIframe } from './utils/prewarm'
 import {
   AccessTokenPayload,
@@ -266,6 +270,8 @@ describe('createLink tests', () => {
       symbol: 'BTC',
       amount: 0.001,
       networkId: 'nid',
+      userId: 'uid',
+      clientTransactionId: 'ctid',
       amountInFiat: 9.77,
       totalAmountInFiat: 10.02,
       networkName: 'Bitcoin',
@@ -287,6 +293,117 @@ describe('createLink tests', () => {
       payload: payload
     })
     expect(onTransferFinishedHandler).toHaveBeenCalledWith(payload)
+  })
+
+  test('createLink "transferFinished" event without userId or clientTransactionId should still send transfer payload', () => {
+    const onEventHandler = jest.fn<void, [LinkEventType]>()
+    const onTransferFinishedHandler = jest.fn<void, [TransferFinishedPayload]>()
+    const frontConnection = createLink({
+      clientId: 'test',
+      onIntegrationConnected: jest.fn(),
+      onEvent: onEventHandler,
+      onTransferFinished: onTransferFinishedHandler
+    })
+
+    frontConnection.openLink(BASE64_ENCODED_URL)
+
+    const payload: TransferFinishedPayload = {
+      status: 'success',
+      txId: 'tid',
+      fromAddress: 'fa',
+      toAddress: 'ta',
+      symbol: 'BTC',
+      amount: 0.001,
+      networkId: 'nid'
+    }
+    window.dispatchEvent(
+      new MessageEvent<EventPayload>('message', {
+        data: {
+          type: 'transferFinished',
+          payload: payload
+        },
+        origin: 'http://localhost'
+      })
+    )
+
+    expect(onEventHandler).toHaveBeenCalledWith({
+      type: 'transferCompleted',
+      payload: payload
+    })
+    expect(onTransferFinishedHandler).toHaveBeenCalledWith(payload)
+    expect(onTransferFinishedHandler.mock.calls[0][0].userId).toBeUndefined()
+    expect(
+      onTransferFinishedHandler.mock.calls[0][0].clientTransactionId
+    ).toBeUndefined()
+  })
+
+  test('createLink "transferExecuted" event forwards userId and clientTransactionId via onEvent', () => {
+    const onEventHandler = jest.fn<void, [LinkEventType]>()
+    const frontConnection = createLink({
+      clientId: 'test',
+      onIntegrationConnected: jest.fn(),
+      onEvent: onEventHandler
+    })
+
+    frontConnection.openLink(BASE64_ENCODED_URL)
+
+    const event: TransferExecuted = {
+      type: 'transferExecuted',
+      payload: {
+        status: 'success',
+        txId: 'tid',
+        fromAddress: 'fa',
+        toAddress: 'ta',
+        symbol: 'BTC',
+        amount: 0.001,
+        networkId: 'nid',
+        userId: 'uid',
+        clientTransactionId: 'ctid'
+      }
+    }
+    window.dispatchEvent(
+      new MessageEvent<LinkEventType>('message', {
+        data: event,
+        origin: 'http://localhost'
+      })
+    )
+
+    expect(onEventHandler).toHaveBeenCalledWith(event)
+  })
+
+  test('createLink "transferExecuted" event without userId or clientTransactionId still forwards via onEvent', () => {
+    const onEventHandler = jest.fn<void, [LinkEventType]>()
+    const frontConnection = createLink({
+      clientId: 'test',
+      onIntegrationConnected: jest.fn(),
+      onEvent: onEventHandler
+    })
+
+    frontConnection.openLink(BASE64_ENCODED_URL)
+
+    const event: TransferExecuted = {
+      type: 'transferExecuted',
+      payload: {
+        status: 'success',
+        txId: 'tid',
+        fromAddress: 'fa',
+        toAddress: 'ta',
+        symbol: 'BTC',
+        amount: 0.001,
+        networkId: 'nid'
+      }
+    }
+    window.dispatchEvent(
+      new MessageEvent<LinkEventType>('message', {
+        data: event,
+        origin: 'http://localhost'
+      })
+    )
+
+    expect(onEventHandler).toHaveBeenCalledWith(event)
+    const forwarded = onEventHandler.mock.calls[0][0] as TransferExecuted
+    expect(forwarded.payload.userId).toBeUndefined()
+    expect(forwarded.payload.clientTransactionId).toBeUndefined()
   })
 
   test('createLink "loaded" event should trigger the passing for tokens', () => {

--- a/packages/link/src/utils/event-types.ts
+++ b/packages/link/src/utils/event-types.ts
@@ -149,6 +149,8 @@ export interface TransferExecuted extends LinkEventBase {
     symbol: string
     amount: number
     networkId: string
+    userId?: string
+    clientTransactionId?: string
   }
 }
 

--- a/packages/link/src/utils/types.ts
+++ b/packages/link/src/utils/types.ts
@@ -95,6 +95,8 @@ export interface TransferFinishedPayload {
   symbol: string
   amount: number
   networkId: string
+  userId?: string
+  clientTransactionId?: string
   amountInFiat?: number
   totalAmountInFiat?: number
   networkName?: string


### PR DESCRIPTION
…and TransferExecuted

Adds the two new optional fields that the front-web-platform sender (MD-421) now ships on transferFinished and transferExecuted events, so TypeScript consumers can access them without type errors. Fields are typed optional to match the sender contract, which emits userId as optional.

Test coverage: both event types now have present-field and absent-field cases.