### PR TITLE
PRG-2463 brockerType exported

### DIFF
--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -131,7 +131,7 @@ TypeScript definitions for `@meshconnect/web-link-sdk` are built into the npm pa
 | `DelayedAuthPayload`     | Delayed auth details within `LinkPayload`                                             |
 | `IntegrationAccessToken` | Access token shape used in the `accessTokens` option                                  |
 | `TransferFinishedPayload`| Payload passed to `onTransferFinished`                                                |
-| `BrokerType`             | Enum of supported broker/integration types (re-exported from `@meshconnect/node-api`) |
+| `BrokerType`             | Union of supported broker/integration type strings (re-exported from `@meshconnect/node-api`) |
 | `LinkOptions`            | Full options object passed to `createLink`                                            |
 | `Link`                   | Return type of `createLink`                                                           |
 | `AccountToken`           | Account token within `AccessTokenPayload`                                             |

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -121,3 +121,19 @@ You can use broker tokens to perform requests to get current balance, assets and
 ## Typescript support
 
 TypeScript definitions for `@meshconnect/web-link-sdk` are built into the npm package.
+
+### Exported types
+
+| type                     | description                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| `LinkPayload`            | Payload passed to `onIntegrationConnected`                                            |
+| `AccessTokenPayload`     | Broker access token details within `LinkPayload`                                      |
+| `DelayedAuthPayload`     | Delayed auth details within `LinkPayload`                                             |
+| `IntegrationAccessToken` | Access token shape used in the `accessTokens` option                                  |
+| `TransferFinishedPayload`| Payload passed to `onTransferFinished`                                                |
+| `BrokerType`             | Enum of supported broker/integration types (re-exported from `@meshconnect/node-api`) |
+| `LinkOptions`            | Full options object passed to `createLink`                                            |
+| `Link`                   | Return type of `createLink`                                                           |
+| `AccountToken`           | Account token within `AccessTokenPayload`                                             |
+| `Account`                | Account details within `AccountToken`                                                 |
+| `BrandInfo`              | Integration brand/logo info                                                           |

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.5",
+  "version": "3.9.6",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/link/src/index.ts
+++ b/packages/link/src/index.ts
@@ -1,3 +1,4 @@
 export * from './utils/types'
 export * from './utils/event-types'
 export { createLink } from './Link'
+export type { BrokerType } from '@meshconnect/node-api'

--- a/packages/link/src/utils/types.ts
+++ b/packages/link/src/utils/types.ts
@@ -1,8 +1,6 @@
 import type { BrokerType } from '@meshconnect/node-api'
 import { SessionSummary, LinkEventType } from './event-types'
 
-export type { BrokerType }
-
 export type EventType =
   | 'brokerageAccountAccessToken'
   | 'delayedAuthentication'

--- a/packages/link/src/utils/types.ts
+++ b/packages/link/src/utils/types.ts
@@ -1,6 +1,8 @@
 import type { BrokerType } from '@meshconnect/node-api'
 import { SessionSummary, LinkEventType } from './event-types'
 
+export type { BrokerType }
+
 export type EventType =
   | 'brokerageAccountAccessToken'
   | 'delayedAuthentication'


### PR DESCRIPTION
Ticket: https://meshconnectapi.atlassian.net/browse/PRG-2463
Changes:                                                                                                                                         
  - packages/link/src/utils/index.ts — BrokerType re-export added                                                                                                                                         
  - packages/link/README.md — exported types table added
  - packages/link/package.json — version bumped to 3.9.6  