### PR TITLE
PRG-2500 Send closeRequested message to iframe in embedded mode

### DIFF
--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -576,6 +576,37 @@ describe('createLink tests', () => {
     )
   })
 
+  test('createLink closeLink in embedded mode should send closeRequested message to iframe instead of closing', () => {
+    const exitFunction = jest.fn<void, [string | undefined]>()
+    const customIframeId = 'embedded-close-iframe'
+    const customIframeElement = document.createElement('iframe')
+    customIframeElement.id = customIframeId
+    document.body.appendChild(customIframeElement)
+
+    const frontConnection = createLink({
+      clientId: 'test',
+      onIntegrationConnected: jest.fn(),
+      onExit: exitFunction,
+      renderType: 'embedded',
+      language: 'en'
+    })
+
+    frontConnection.openLink(BASE64_ENCODED_URL, customIframeId)
+
+    const postMessageSpy = jest.spyOn(
+      customIframeElement.contentWindow as Window,
+      'postMessage'
+    )
+
+    frontConnection.closeLink()
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: 'closeRequested' },
+      'http://localhost'
+    )
+    expect(exitFunction).not.toHaveBeenCalled()
+  })
+
   test('createLink without renderType should not append rt param to src', () => {
     const frontConnection = createLink({
       clientId: 'test',

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -196,6 +196,10 @@ export const createLink = (options: LinkOptions): Link => {
   }
 
   const closeLink = () => {
+    if (currentOptions?.renderType === 'embedded') {
+      sendMessageToIframe({ type: 'closeRequested' })
+      return
+    }
     bridgeParent?.destroy()
     removePopup()
     window.removeEventListener('message', eventsListener)


### PR DESCRIPTION
## Summary
- When the host app calls `closeLink()` in embedded mode, the SDK now sends a `{ type: 'closeRequested' }` postMessage to the iframe instead of immediately tearing down
- This lets the Link UI run its own close logic (confirmation dialog, manual QR flow, etc.) before sending back `close`/`done`
- Overlay mode (default) behavior is unchanged

## Jira
[PRG-2500](https://meshconnectapi.atlassian.net/browse/PRG-2500)

## Test plan
- [ ] Verify embedded mode: `closeLink()` sends `closeRequested` to iframe, does not immediately call `onExit`
- [ ] Verify overlay mode: `closeLink()` still immediately closes and calls `onExit`
- [ ] Verify Link UI in iframe receives `closeRequested` and can trigger its close flow
- [ ] Verify Link UI sends `close`/`done` back after its flow, and SDK handles cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRG-2500]: https://meshconnectapi.atlassian.net/browse/PRG-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ