### PR TITLE
fix(link): delegate camera permission to Link iframe

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -31,7 +31,7 @@ type EventPayload = {
 const BASE64_ENCODED_URL = Buffer.from('http://localhost/1').toString('base64')
 
 describe('createLink tests', () => {
-  window.open = jest.fn()
+  globalThis.open = jest.fn()
 
   beforeEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = ''
@@ -123,6 +123,8 @@ describe('createLink tests', () => {
       'http://localhost/1?lng=en'
     )
     expect(customIframeElement.allow).toContain('camera http://localhost')
+    expect(customIframeElement.allow).toContain('microphone http://localhost')
+    expect(customIframeElement.allow).toContain('https://api.sumsub.com')
   })
 
   test('createLink closePopup should close popup', () => {
@@ -158,7 +160,7 @@ describe('createLink tests', () => {
         errorMessage: 'some msg'
       }
       frontConnection.openLink(BASE64_ENCODED_URL)
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<LinkEventType>('message', {
           data: {
             type: eventName,
@@ -192,7 +194,7 @@ describe('createLink tests', () => {
       brokerType: 'robinhood',
       brokerName: 'R'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'brokerageAccountAccessToken',
@@ -228,7 +230,7 @@ describe('createLink tests', () => {
       brokerName: 'R',
       refreshToken: 'rt'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'delayedAuthentication',
@@ -296,7 +298,7 @@ describe('createLink tests', () => {
 
       frontConnection.openLink(BASE64_ENCODED_URL)
 
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<EventPayload>('message', {
           data: { type: 'transferFinished', payload: payload },
           origin: 'http://localhost'
@@ -342,7 +344,7 @@ describe('createLink tests', () => {
           ...extra
         }
       }
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<LinkEventType>('message', {
           data: event,
           origin: 'http://localhost'
@@ -381,7 +383,7 @@ describe('createLink tests', () => {
       'postMessage'
     )
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'loaded'
@@ -422,7 +424,7 @@ describe('createLink tests', () => {
 
     frontConnection.openLink(BASE64_ENCODED_URL)
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent('message', {
         data: {
           type: 'integrationConnected'
@@ -444,7 +446,7 @@ describe('createLink tests', () => {
 
     frontConnection.openLink(BASE64_ENCODED_URL)
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent('message', {
         data: {
           type: 'unknown'
@@ -475,7 +477,7 @@ describe('createLink tests', () => {
       brokerType: 'robinhood',
       brokerName: 'R'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'brokerageAccountAccessToken',

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -457,43 +457,6 @@ describe('createLink tests', () => {
     expect(onEventHandler).not.toHaveBeenCalled()
   })
 
-  test('createLink "brokerageAccountAccessToken" event should send tokens - used with openLink function', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const onBrokerConnectedHandler = jest.fn<void, [LinkPayload]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: onBrokerConnectedHandler,
-      onEvent: onEventHandler
-    })
-
-    frontConnection.openLink(
-      Buffer.from('http://localhost/1').toString('base64')
-    )
-
-    const payload: AccessTokenPayload = {
-      accountTokens: [],
-      brokerBrandInfo: { brokerLogo: '' },
-      brokerType: 'robinhood',
-      brokerName: 'R'
-    }
-    globalThis.dispatchEvent(
-      new MessageEvent<EventPayload>('message', {
-        data: {
-          type: 'brokerageAccountAccessToken',
-          payload: payload
-        },
-        origin: 'http://localhost'
-      })
-    )
-
-    expect(onEventHandler).toHaveBeenCalledWith({
-      type: 'integrationConnected',
-      payload: { accessToken: payload }
-    })
-    expect(onBrokerConnectedHandler).toHaveBeenCalledWith({
-      accessToken: payload
-    })
-  })
 
   test('createLink closeLink should close popup', () => {
     const exitFunction = jest.fn<void, [string | undefined]>()

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -124,7 +124,6 @@ describe('createLink tests', () => {
     )
     expect(customIframeElement.allow).toContain('camera http://localhost')
     expect(customIframeElement.allow).toContain('microphone http://localhost')
-    expect(customIframeElement.allow).toContain('https://api.sumsub.com')
   })
 
   test('createLink closePopup should close popup', () => {

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -122,6 +122,7 @@ describe('createLink tests', () => {
     expect(customIframeElement.attributes.getNamedItem('src')?.nodeValue).toBe(
       'http://localhost/1?lng=en'
     )
+    expect(customIframeElement.allow).toContain('camera http://localhost')
   })
 
   test('createLink closePopup should close popup', () => {

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -457,7 +457,6 @@ describe('createLink tests', () => {
     expect(onEventHandler).not.toHaveBeenCalled()
   })
 
-
   test('createLink closeLink should close popup', () => {
     const exitFunction = jest.fn<void, [string | undefined]>()
     const frontConnection = createLink({

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = `clipboard-read *; clipboard-write *; camera ${new URL(linkUrl).origin}`
+        iframe.allow = `clipboard-read *; clipboard-write *; camera ${linkTokenOrigin}`
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -7,7 +7,12 @@ import {
   TransferFinishedPayload,
   LinkPayload
 } from './utils/types'
-import { addPopup, iframeId, removePopup } from './utils/popup'
+import {
+  addPopup,
+  buildIframeAllowPolicy,
+  iframeId,
+  removePopup
+} from './utils/popup'
 import { LinkEventType, isLinkEventTypeKey } from './utils/event-types'
 import { sdkSpecs } from './utils/sdk-specs'
 import { appendQueryParam } from './utils/url'
@@ -173,7 +178,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = `clipboard-read *; clipboard-write *; camera ${linkTokenOrigin}`
+        iframe.allow = buildIframeAllowPolicy(linkTokenOrigin!)
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = 'clipboard-read *; clipboard-write *; camera *'
+        iframe.allow = `clipboard-read *; clipboard-write *; camera ${new URL(linkUrl).origin}`
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = 'clipboard-read *; clipboard-write *'
+        iframe.allow = 'clipboard-read *; clipboard-write *; camera *'
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -17,7 +17,6 @@ describe('Popup tests', () => {
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
     expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
     expect((iframeElement as HTMLIFrameElement).allow).toContain('microphone https://some.domain')
-    expect((iframeElement as HTMLIFrameElement).allow).toContain('https://api.sumsub.com')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -15,6 +15,7 @@ describe('Popup tests', () => {
     const iframeElement = document.getElementById('mesh-link-popup__iframe')
     expect(iframeElement).toBeTruthy()
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -16,6 +16,8 @@ describe('Popup tests', () => {
     expect(iframeElement).toBeTruthy()
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
     expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('microphone https://some.domain')
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('https://api.sumsub.com')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -90,10 +90,8 @@ const getStylesContent = (style?: LinkStyle) => `
   }
 `
 
-const SUMSUB_ORIGINS = 'https://api.sumsub.com https://api.sns-stage.sumsub.com'
-
 export function buildIframeAllowPolicy(origin: string): string {
-  return `clipboard-read *; clipboard-write *; camera ${origin} ${SUMSUB_ORIGINS}; microphone ${origin} ${SUMSUB_ORIGINS}`
+  return `clipboard-read *; clipboard-write *; camera ${origin}; microphone ${origin}`
 }
 
 export function removePopup(): void {

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -90,6 +90,12 @@ const getStylesContent = (style?: LinkStyle) => `
   }
 `
 
+const SUMSUB_ORIGINS = 'https://api.sumsub.com https://api.sns-stage.sumsub.com'
+
+export function buildIframeAllowPolicy(origin: string): string {
+  return `clipboard-read *; clipboard-write *; camera ${origin} ${SUMSUB_ORIGINS}; microphone ${origin} ${SUMSUB_ORIGINS}`
+}
+
 export function removePopup(): void {
   const existingPopup = window.document.getElementById(popupId)
   existingPopup?.parentElement?.removeChild(existingPopup)
@@ -117,7 +123,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = `clipboard-read *; clipboard-write *; camera ${new URL(iframeLink).origin}`
+  iframeElement.allow = buildIframeAllowPolicy(new URL(iframeLink).origin)
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -117,7 +117,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = 'clipboard-read *; clipboard-write *; camera *'
+  iframeElement.allow = `clipboard-read *; clipboard-write *; camera ${new URL(iframeLink).origin}`
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -117,7 +117,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = 'clipboard-read *; clipboard-write *'
+  iframeElement.allow = 'clipboard-read *; clipboard-write *; camera *'
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)


### PR DESCRIPTION
## Summary

- Delegate `camera` and `microphone` permissions (origin-scoped) to the iframe `allow` attribute in both popup and custom iframe flows
- Without this, embedded flows that require camera/microphone access (e.g. KYC with Sumsub liveness check) are blocked by the browser's Permissions Policy
- Extracts a shared `buildIframeAllowPolicy` helper so popup and custom iframe flows stay in sync
- Bumps version `3.9.7` → `3.9.8`

## Problem

The popup and custom iframes only delegated `clipboard-read` and `clipboard-write` permissions. When a host page grants camera access to its own origin, that permission is not automatically inherited by cross-origin iframes — it must be explicitly delegated via the `allow` attribute. This caused Sumsub's KYC SDK (rendered inside the Link iframe) to be denied camera and microphone access.

The `@sumsub/websdk-react` package accesses camera/microphone directly in the parent frame's JS context, so scoping the delegation to the Link iframe origin is sufficient — no third-party origins needed.

## Changes

- `packages/link/src/utils/popup.ts` — added `buildIframeAllowPolicy` helper; delegates `camera` and `microphone` scoped to the iframe origin
- `packages/link/src/Link.ts` — uses `buildIframeAllowPolicy`; reuses the already-computed `linkTokenOrigin` to avoid double-parsing the URL
- `packages/link/src/utils/popup.test.ts` — asserts camera and microphone are present in allow policy
- `packages/link/src/Link.test.ts` — asserts camera and microphone are present; removed duplicate `brokerageAccountAccessToken` test; replaced `window` with `globalThis` for es2020 portability
- `packages/link/package.json` — bumped version to `3.9.8`

## Testing

- Opened Link via popup overlay on a host page with camera permission granted
- Navigated to the KYC screen (Sumsub WebSDK)
- Confirmed camera access is granted and liveness check loads correctly
- Confirmed no regression on clipboard-based flows