### PR TITLE
feat(node-api): add fiatOnRamp and fiatOffRamp transfer types [FIAT-82]

### DIFF
--- a/.github/workflows/mesh.b2b.deploy.link.yml
+++ b/.github/workflows/mesh.b2b.deploy.link.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: yarn config set registry https://registry.npmjs.org/
       - run: yarn
       - run: cd packages/link && yarn publish:npm
         env:

--- a/.github/workflows/mesh.b2b.deploy.node.api.yml
+++ b/.github/workflows/mesh.b2b.deploy.node.api.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: yarn config set registry https://registry.npmjs.org/
       - run: yarn
       - run: cd packages/node-api && yarn publish:npm
         env:

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -31,7 +31,7 @@ type EventPayload = {
 const BASE64_ENCODED_URL = Buffer.from('http://localhost/1').toString('base64')
 
 describe('createLink tests', () => {
-  window.open = jest.fn()
+  globalThis.open = jest.fn()
 
   beforeEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = ''
@@ -123,6 +123,8 @@ describe('createLink tests', () => {
       'http://localhost/1?lng=en'
     )
     expect(customIframeElement.allow).toContain('camera http://localhost')
+    expect(customIframeElement.allow).toContain('microphone http://localhost')
+    expect(customIframeElement.allow).toContain('https://api.sumsub.com')
   })
 
   test('createLink closePopup should close popup', () => {
@@ -158,7 +160,7 @@ describe('createLink tests', () => {
         errorMessage: 'some msg'
       }
       frontConnection.openLink(BASE64_ENCODED_URL)
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<LinkEventType>('message', {
           data: {
             type: eventName,
@@ -192,7 +194,7 @@ describe('createLink tests', () => {
       brokerType: 'robinhood',
       brokerName: 'R'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'brokerageAccountAccessToken',
@@ -228,7 +230,7 @@ describe('createLink tests', () => {
       brokerName: 'R',
       refreshToken: 'rt'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'delayedAuthentication',
@@ -296,7 +298,7 @@ describe('createLink tests', () => {
 
       frontConnection.openLink(BASE64_ENCODED_URL)
 
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<EventPayload>('message', {
           data: { type: 'transferFinished', payload: payload },
           origin: 'http://localhost'
@@ -342,7 +344,7 @@ describe('createLink tests', () => {
           ...extra
         }
       }
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new MessageEvent<LinkEventType>('message', {
           data: event,
           origin: 'http://localhost'
@@ -381,7 +383,7 @@ describe('createLink tests', () => {
       'postMessage'
     )
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'loaded'
@@ -422,7 +424,7 @@ describe('createLink tests', () => {
 
     frontConnection.openLink(BASE64_ENCODED_URL)
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent('message', {
         data: {
           type: 'integrationConnected'
@@ -444,7 +446,7 @@ describe('createLink tests', () => {
 
     frontConnection.openLink(BASE64_ENCODED_URL)
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent('message', {
         data: {
           type: 'unknown'
@@ -475,7 +477,7 @@ describe('createLink tests', () => {
       brokerType: 'robinhood',
       brokerName: 'R'
     }
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent<EventPayload>('message', {
         data: {
           type: 'brokerageAccountAccessToken',

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -457,43 +457,6 @@ describe('createLink tests', () => {
     expect(onEventHandler).not.toHaveBeenCalled()
   })
 
-  test('createLink "brokerageAccountAccessToken" event should send tokens - used with openLink function', () => {
-    const onEventHandler = jest.fn<void, [LinkEventType]>()
-    const onBrokerConnectedHandler = jest.fn<void, [LinkPayload]>()
-    const frontConnection = createLink({
-      clientId: 'test',
-      onIntegrationConnected: onBrokerConnectedHandler,
-      onEvent: onEventHandler
-    })
-
-    frontConnection.openLink(
-      Buffer.from('http://localhost/1').toString('base64')
-    )
-
-    const payload: AccessTokenPayload = {
-      accountTokens: [],
-      brokerBrandInfo: { brokerLogo: '' },
-      brokerType: 'robinhood',
-      brokerName: 'R'
-    }
-    globalThis.dispatchEvent(
-      new MessageEvent<EventPayload>('message', {
-        data: {
-          type: 'brokerageAccountAccessToken',
-          payload: payload
-        },
-        origin: 'http://localhost'
-      })
-    )
-
-    expect(onEventHandler).toHaveBeenCalledWith({
-      type: 'integrationConnected',
-      payload: { accessToken: payload }
-    })
-    expect(onBrokerConnectedHandler).toHaveBeenCalledWith({
-      accessToken: payload
-    })
-  })
 
   test('createLink closeLink should close popup', () => {
     const exitFunction = jest.fn<void, [string | undefined]>()

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -124,7 +124,6 @@ describe('createLink tests', () => {
     )
     expect(customIframeElement.allow).toContain('camera http://localhost')
     expect(customIframeElement.allow).toContain('microphone http://localhost')
-    expect(customIframeElement.allow).toContain('https://api.sumsub.com')
   })
 
   test('createLink closePopup should close popup', () => {

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -122,6 +122,7 @@ describe('createLink tests', () => {
     expect(customIframeElement.attributes.getNamedItem('src')?.nodeValue).toBe(
       'http://localhost/1?lng=en'
     )
+    expect(customIframeElement.allow).toContain('camera http://localhost')
   })
 
   test('createLink closePopup should close popup', () => {

--- a/packages/link/src/Link.test.ts
+++ b/packages/link/src/Link.test.ts
@@ -457,7 +457,6 @@ describe('createLink tests', () => {
     expect(onEventHandler).not.toHaveBeenCalled()
   })
 
-
   test('createLink closeLink should close popup', () => {
     const exitFunction = jest.fn<void, [string | undefined]>()
     const frontConnection = createLink({

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = `clipboard-read *; clipboard-write *; camera ${new URL(linkUrl).origin}`
+        iframe.allow = `clipboard-read *; clipboard-write *; camera ${linkTokenOrigin}`
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -7,7 +7,12 @@ import {
   TransferFinishedPayload,
   LinkPayload
 } from './utils/types'
-import { addPopup, iframeId, removePopup } from './utils/popup'
+import {
+  addPopup,
+  buildIframeAllowPolicy,
+  iframeId,
+  removePopup
+} from './utils/popup'
 import { LinkEventType, isLinkEventTypeKey } from './utils/event-types'
 import { sdkSpecs } from './utils/sdk-specs'
 import { appendQueryParam } from './utils/url'
@@ -173,7 +178,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = `clipboard-read *; clipboard-write *; camera ${linkTokenOrigin}`
+        iframe.allow = buildIframeAllowPolicy(linkTokenOrigin!)
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = 'clipboard-read *; clipboard-write *; camera *'
+        iframe.allow = `clipboard-read *; clipboard-write *; camera ${new URL(linkUrl).origin}`
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -173,7 +173,7 @@ export const createLink = (options: LinkOptions): Link => {
         customIframeId
       ) as HTMLIFrameElement
       if (iframe) {
-        iframe.allow = 'clipboard-read *; clipboard-write *'
+        iframe.allow = 'clipboard-read *; clipboard-write *; camera *'
         iframe.src = linkUrl
         currentIframeId = customIframeId
       } else {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -17,7 +17,6 @@ describe('Popup tests', () => {
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
     expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
     expect((iframeElement as HTMLIFrameElement).allow).toContain('microphone https://some.domain')
-    expect((iframeElement as HTMLIFrameElement).allow).toContain('https://api.sumsub.com')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -15,6 +15,7 @@ describe('Popup tests', () => {
     const iframeElement = document.getElementById('mesh-link-popup__iframe')
     expect(iframeElement).toBeTruthy()
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.test.ts
+++ b/packages/link/src/utils/popup.test.ts
@@ -16,6 +16,8 @@ describe('Popup tests', () => {
     expect(iframeElement).toBeTruthy()
     expect(iframeElement?.attributes.getNamedItem('src')?.nodeValue).toBe(link)
     expect((iframeElement as HTMLIFrameElement).allow).toContain('camera https://some.domain')
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('microphone https://some.domain')
+    expect((iframeElement as HTMLIFrameElement).allow).toContain('https://api.sumsub.com')
   })
 
   test('addPopup when popup already added should replace popup', () => {

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -90,10 +90,8 @@ const getStylesContent = (style?: LinkStyle) => `
   }
 `
 
-const SUMSUB_ORIGINS = 'https://api.sumsub.com https://api.sns-stage.sumsub.com'
-
 export function buildIframeAllowPolicy(origin: string): string {
-  return `clipboard-read *; clipboard-write *; camera ${origin} ${SUMSUB_ORIGINS}; microphone ${origin} ${SUMSUB_ORIGINS}`
+  return `clipboard-read *; clipboard-write *; camera ${origin}; microphone ${origin}`
 }
 
 export function removePopup(): void {

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -90,6 +90,12 @@ const getStylesContent = (style?: LinkStyle) => `
   }
 `
 
+const SUMSUB_ORIGINS = 'https://api.sumsub.com https://api.sns-stage.sumsub.com'
+
+export function buildIframeAllowPolicy(origin: string): string {
+  return `clipboard-read *; clipboard-write *; camera ${origin} ${SUMSUB_ORIGINS}; microphone ${origin} ${SUMSUB_ORIGINS}`
+}
+
 export function removePopup(): void {
   const existingPopup = window.document.getElementById(popupId)
   existingPopup?.parentElement?.removeChild(existingPopup)
@@ -117,7 +123,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = `clipboard-read *; clipboard-write *; camera ${new URL(iframeLink).origin}`
+  iframeElement.allow = buildIframeAllowPolicy(new URL(iframeLink).origin)
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -117,7 +117,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = 'clipboard-read *; clipboard-write *; camera *'
+  iframeElement.allow = `clipboard-read *; clipboard-write *; camera ${new URL(iframeLink).origin}`
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)

--- a/packages/link/src/utils/popup.ts
+++ b/packages/link/src/utils/popup.ts
@@ -117,7 +117,7 @@ export function addPopup(iframeLink: string): void {
   const iframeElement = document.createElement('iframe')
   iframeElement.id = iframeId
   iframeElement.src = iframeLink
-  iframeElement.allow = 'clipboard-read *; clipboard-write *'
+  iframeElement.allow = 'clipboard-read *; clipboard-write *; camera *'
   popupContentElement.appendChild(iframeElement)
   popupRootElement.appendChild(popupContentElement)
   window.document.body.appendChild(popupRootElement)

--- a/packages/node-api/api.ts
+++ b/packages/node-api/api.ts
@@ -5717,8 +5717,10 @@ export interface PreviewTransferResult {
    * Deposit: The user is transferring crypto to a wallet they own on your platform.
    * Payment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.
    * Onramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform.
+   * FiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).
+   * FiatOffRamp: The user is selling crypto to receive fiat via a bank transfer.
    */
-  transferType?: 'deposit' | 'payment' | 'onramp'
+  transferType?: 'deposit' | 'payment' | 'onramp' | 'fiatOnRamp' | 'fiatOffRamp'
   isCustomClientFeeProvided?: boolean
   /**
    * Amount in symbol after the client fees are applied. This field represents the exact amount
@@ -7323,7 +7325,7 @@ export interface TransferTravelRuleOptions {
   clientId?: string
 }
 
-export type TransferTypeEnum = 'deposit' | 'payment' | 'onramp'
+export type TransferTypeEnum = 'deposit' | 'payment' | 'onramp' | 'fiatOnRamp' | 'fiatOffRamp'
 
 export interface TransferVerificationRequest {
   integrationId?: string | null

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/node-api",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "A node.js client library for the Mesh API",
   "type": "module",
   "main": "./index.ts",


### PR DESCRIPTION
## Summary
- Adds `fiatOnRamp` and `fiatOffRamp` to `TransferTypeEnum` in `@meshconnect/node-api`
- Updates the inline `transferType` literal union on the link token request body to match
- Updates JSDoc to describe the new types
- Bumps `@meshconnect/node-api` version `2.0.25` → `2.0.26`

## Context
The existing `onramp` transfer type is used for broker-based onramp flows (PayPal, Coinbase, etc.). Clients may want both broker onramp and fiat ramp sessions simultaneously, so fiat ramps need their own distinct transfer types:
- `fiatOnRamp` — bank transfer → crypto (e.g. SPEI, SEPA via Unlimit)
- `fiatOffRamp` — crypto → bank transfer (future)

## Test plan
- [ ] No test files exist in `node-api` (generated client) — no test changes needed
- [ ] Verify `TransferTypeEnum` includes all five values after build
- [ ] After publishing `2.0.26`, bump dependency in `front-web-platform` and remove local `node_modules` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)