### PR TITLE
feat(node-api): add fiatOnRamp and fiatOffRamp transfer types [FIAT-82]

### DIFF
--- a/packages/node-api/api.ts
+++ b/packages/node-api/api.ts
@@ -4383,6 +4383,8 @@ export interface InitializeTransfersForLinkRequest {
    * Deposit (default): The user is transferring crypto to a wallet they own on your platform.
    * Payment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.
    * Onramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform.
+   * FiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).
+   * FiatOffRamp: The user is selling crypto to receive fiat via a bank transfer.
    */
   transferType?: TransferTypeEnum | null
   /**
@@ -4796,6 +4798,8 @@ export interface LinkTokenTransferOptions {
    * Deposit: The user is transferring crypto to a wallet they own on your platform.
    * Payment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.
    * Onramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform.
+   * FiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).
+   * FiatOffRamp: The user is selling crypto to receive fiat via a bank transfer.
    */
   transferType?: TransferTypeEnum | null
   /**
@@ -5720,7 +5724,7 @@ export interface PreviewTransferResult {
    * FiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).
    * FiatOffRamp: The user is selling crypto to receive fiat via a bank transfer.
    */
-  transferType?: 'deposit' | 'payment' | 'onramp' | 'fiatOnRamp' | 'fiatOffRamp'
+  transferType?: TransferTypeEnum | null
   isCustomClientFeeProvided?: boolean
   /**
    * Amount in symbol after the client fees are applied. This field represents the exact amount

--- a/packages/node-api/api.ts
+++ b/packages/node-api/api.ts
@@ -5717,8 +5717,10 @@ export interface PreviewTransferResult {
    * Deposit: The user is transferring crypto to a wallet they own on your platform.
    * Payment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.
    * Onramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform.
+   * FiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).
+   * FiatOffRamp: The user is selling crypto to receive fiat via a bank transfer.
    */
-  transferType?: 'deposit' | 'payment' | 'onramp'
+  transferType?: 'deposit' | 'payment' | 'onramp' | 'fiatOnRamp' | 'fiatOffRamp'
   isCustomClientFeeProvided?: boolean
   /**
    * Amount in symbol after the client fees are applied. This field represents the exact amount
@@ -7323,7 +7325,7 @@ export interface TransferTravelRuleOptions {
   clientId?: string
 }
 
-export type TransferTypeEnum = 'deposit' | 'payment' | 'onramp'
+export type TransferTypeEnum = 'deposit' | 'payment' | 'onramp' | 'fiatOnRamp' | 'fiatOffRamp'
 
 export interface TransferVerificationRequest {
   integrationId?: string | null

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/node-api",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "A node.js client library for the Mesh API",
   "type": "module",
   "main": "./index.ts",

--- a/packages/node-api/swagger.json
+++ b/packages/node-api/swagger.json
@@ -12991,14 +12991,16 @@
             "enum": [
               "deposit",
               "payment",
-              "onramp"
+              "onramp",
+              "fiatOnRamp",
+              "fiatOffRamp"
             ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/TransferTypeEnum"
               }
             ],
-            "description": "Deposit: The user is transferring crypto to a wallet they own on your platform.\r\nPayment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.\r\nOnramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform."
+            "description": "Deposit: The user is transferring crypto to a wallet they own on your platform.\r\nPayment: The user is transferring crypto to a wallet your company owns in exchange for receiving a good or service.\r\nOnramp: The user is using balances and linked payment methods in an exchange account to fund the purchase of crypto in their wallet on your platform.\r\nFiatOnRamp: The user is purchasing crypto using a bank transfer (e.g. SPEI, SEPA).\r\nFiatOffRamp: The user is selling crypto to receive fiat via a bank transfer."
           },
           "isCustomClientFeeProvided": {
             "type": "boolean"
@@ -15292,7 +15294,9 @@
         "enum": [
           "deposit",
           "payment",
-          "onramp"
+          "onramp",
+          "fiatOnRamp",
+          "fiatOffRamp"
         ],
         "type": "string"
       },


### PR DESCRIPTION
## Summary
- Adds `fiatOnRamp` and `fiatOffRamp` to `TransferTypeEnum` in `@meshconnect/node-api`
- Updates the inline `transferType` literal union on the link token request body to match
- Updates JSDoc to describe the new types
- Bumps `@meshconnect/node-api` version `2.0.25` → `2.0.26`

## Context
The existing `onramp` transfer type is used for broker-based onramp flows (PayPal, Coinbase, etc.). Clients may want both broker onramp and fiat ramp sessions simultaneously, so fiat ramps need their own distinct transfer types:
- `fiatOnRamp` — bank transfer → crypto (e.g. SPEI, SEPA via Unlimit)
- `fiatOffRamp` — crypto → bank transfer (future)


🤖 Generated with [Claude Code](https://claude.com/claude-code)