### PR TITLE
feat(link): upgrade uwc-bridge-parent to 1.4.0 for Solana sign-only [ONC-3346]

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.9.8",
+  "version": "3.10.0",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@meshconnect/node-api": "^2.0.25",
-    "@meshconnect/uwc-bridge-parent": "1.3.1"
+    "@meshconnect/uwc-bridge-parent": "1.4.0"
   },
   "scripts": {
     "build": "yarn updateVersion && rimraf dist && yarn build:esm && yarn copy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,10 +1602,10 @@
     rpc-websockets "^9.0.2"
     superstruct "^2.0.2"
 
-"@meshconnect/uwc-bridge-parent@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.3.1.tgz#ac2d8c525ce9026d3fc1329bd99da4f3e6a42ace"
-  integrity sha512-6SBosxE6SRkZtZB0e1WVw8V5+ni3vgPIe79VrWoT4By+3HcA2/Wz6NKNj6fjYMzBq74JCAGM4jzAsjloDtJVhQ==
+"@meshconnect/uwc-bridge-parent@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@meshconnect/uwc-bridge-parent/-/uwc-bridge-parent-1.4.0.tgz#0b6bdce2f0ea60b70b98cb6a6dca0138b7bb6267"
+  integrity sha512-xAD4971xsA9+O5o7A8bNMDwGCo2cayYo1Fuggfup7cwSMTv1nhYKgzr0BAI5a3UL8lN16h2CNixQI0Mrnuvl/Q==
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.23"
     "@solana/wallet-standard-wallet-adapter-base" "^1.1.4"


### PR DESCRIPTION
## What

Bumps `@meshconnect/uwc-bridge-parent` to the released **1.4.0** (from the testing snapshot). This enables **sign-only Solana signing** through the iframe bridge: the relay pays the network fee and broadcasts, while the wallet only adds the user's signature.

SDK version: **3.9.8 → 3.10.0** (new functionality, backwards compatible).

## Why

The Solana sign-only path added in UWC (FrontFin/universal-wallet-connector#153, released via #155) only switches on once the SDK ships the matching `uwc-bridge-parent`. Until this bump, existing setups keep using the current signing path — no regression.

The `uwc-bridge-parent` 1.4.0 change is **additive only**: it adds the `signSolanaTransactionBytes` handler (and lists it in `customFunctions`); existing `customFunctions` and signing paths in `BridgeParent.ts` are unchanged. So a newer SDK paired with an older Link UI is safe — the child simply doesn't call the new method.

## Validated

Solana **mainnet**, iframe Comlink bridge via this SDK's demo (`examples/react-example`): **MetaMask + Phantom**, USDC — confirmed on-chain, relay paid the gas, the wallet never self-broadcast.

## Note

`yarn install` surfaces a transitive peer-dependency warning — `@solana/wallet-standard-wallet-adapter-base` wants `bs58@^6` while the tree resolves `bs58@^4`. This edge is identical between `uwc-bridge-parent` 1.3.1 and 1.4.0, so it is pre-existing (already present in the published SDK), not introduced here, and non-blocking.
