### PR TITLE
Add npm bugs metadata

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "repository": "https://github.com/FrontFin/mesh-web-sdk.git",
   "homepage": "https://github.com/FrontFin/mesh-web-sdk",
+  "bugs": {
+    "url": "https://github.com/FrontFin/mesh-web-sdk/issues"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.20.0",
     "@babel/preset-typescript": "^7.20.0",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -9,6 +9,9 @@
   "license": "MIT",
   "repository": "https://github.com/FrontFin/mesh-web-sdk.git",
   "homepage": "https://github.com/FrontFin/mesh-web-sdk",
+  "bugs": {
+    "url": "https://github.com/FrontFin/mesh-web-sdk/issues"
+  },
   "devDependencies": {
     "typescript": "^4.6.4",
     "swagger-typescript-api": "^12.0.3"


### PR DESCRIPTION
## Summary
- add bugs metadata for @meshconnect/node-api
- add bugs metadata for @meshconnect/web-link-sdk

## Verification
- node manifest assertion for both packages
- git diff --check
- npm pack --dry-run --json --ignore-scripts in packages/node-api
- npm pack --dry-run --json --ignore-scripts in packages/link