### PR TITLE
chore(ci): SHA-pin GitHub Actions references [PRG-2774]

### DIFF
--- a/.github/workflows/mesh.b2b.deploy.link.yml
+++ b/.github/workflows/mesh.b2b.deploy.link.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20.x
       - name: Install dependencies
@@ -23,9 +23,9 @@ jobs:
     needs:
       - build-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/mesh.b2b.deploy.node.api.yml
+++ b/.github/workflows/mesh.b2b.deploy.node.api.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20.x
       - name: Install dependencies
@@ -23,9 +23,9 @@ jobs:
     needs:
       - build-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/mesh.b2b.pr.yml
+++ b/.github/workflows/mesh.b2b.pr.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20.x
       - name: Install dependencies

--- a/.github/workflows/release-announcement.yaml
+++ b/.github/workflows/release-announcement.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # REQUIRED for tags
 
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/version-details
 
       - name: Send release announcement to Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
Ticket: https://meshconnectapi.atlassian.net/browse/PRG-2774

## Summary

Pin every third-party `uses:` reference in our GitHub Actions workflows to an immutable commit SHA, with the resolved version as a trailing comment for readability.

## Why

Tags in GitHub are mutable — the owner of an action can re-point `v3` (or any tag) to a different commit at any time. If an action's repo is compromised, or a maintainer is socially engineered, a moved tag would silently change the code our CI runs (including in our publish workflows that have access to `NPM_TOKEN`). Pinning to a commit SHA freezes the exact code that runs and makes any change visible in a diff. This is the [GitHub-recommended hardening practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Changes

Resolved each tag to the current commit SHA on the action's repo, kept the version as a trailing comment so future readers can still see what's being pinned:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v3` | `@f43a0e5...` ` # v3.6.0` |
| `actions/checkout` | `@v4` | `@34e1148...` ` # v4.3.1` |
| `actions/setup-node` | `@v3` | `@3235b87...` ` # v3.9.1` |
| `slackapi/slack-github-action` | `@91efab1...` (already pinned) | unchanged, added ` # v2.1.1` comment |

The local action `./.github/actions/version-details` is unchanged — local refs are not affected by this class of supply-chain risk.

Files touched:
- `.github/workflows/mesh.b2b.deploy.link.yml`
- `.github/workflows/mesh.b2b.deploy.node.api.yml`
- `.github/workflows/mesh.b2b.pr.yml`
- `.github/workflows/release-announcement.yaml`

## Testing

No behavior change — each SHA is the current commit that the corresponding tag points to, so the same exact action code runs as before. The PR build workflow (`mesh.b2b.pr.yml`) will exercise the new pins on this PR itself; if any SHA were wrong, CI would fail loudly with an action-resolution error rather than silently running different code.