### PR TITLE
PRG-2584 Patch ajv & brace-expansion (follow-up to #185)

### DIFF
--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -8,7 +8,7 @@
     "@meshconnect/web-link-sdk": "*",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
-    "axios": "1.15.0",
+    "axios": "1.18.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "localforage": "^1.10.0"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/web-link-sdk",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "A client-side JS library for integrating with Mesh Connect",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
@@ -26,7 +26,7 @@
     "util": "^0.12.4"
   },
   "dependencies": {
-    "@meshconnect/node-api": "^2.0.25",
+    "@meshconnect/node-api": "^2.0.27",
     "@meshconnect/uwc-bridge-parent": "1.4.0"
   },
   "scripts": {

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshconnect/node-api",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "A node.js client library for the Mesh API",
   "type": "module",
   "main": "./index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,7 +3170,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@1.12.0, axios@1.15.0, axios@1.18.0:
+axios@1.12.0, axios@1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.0.tgz#8a7f8854af280fcaae063272df2ed9f3837d2398"
   integrity sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,9 +2949,9 @@ aggregate-error@^3.0.0:
     indent-string "^4.0.0"
 
 ajv@^6.10.0, ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -2959,9 +2959,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -3344,9 +3344,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## What
Follow-up to #185 (now merged). Clears the remaining **auto-patchable** transitive advisories under [PRG-2584](https://meshconnectapi.atlassian.net/browse/PRG-2584) / SEC-1131, plus a small example-app dependency bump, **and cuts a release** so the axios patch actually ships to npm.

### 1. Dependency patches
These were deferred from #185 as "cross-major" risks, but on closer inspection both have an **in-major** patch their consumers already accept — so no `resolutions` / forcing is needed. Fixed by re-resolving the stale lockfile entries to the latest in-range version:

- `ajv` `6.12.6 → 6.15.0` and `8.17.1 → 8.20.0` (consumers: `^6.10.0`, `^6.12.4`, `^8.0.1`)
- `brace-expansion` (5.x) `5.0.5 → 5.0.6` (consumers: `^5.0.2`, `^5.0.5`)
- `axios` `1.15.0 → 1.18.0` in the `react-example` app (latest)

### 2. Release bumps
The node-api axios patch from #185 was merged under `2.0.26` **without a version bump**, so the fix never shipped to npm (published `2.0.26` still has axios `1.15.0`). This release re-versions it so the patch actually publishes:

- `@meshconnect/node-api`: `2.0.26 → 2.0.27` (publishes the patched axios `1.18.0`)
- `@meshconnect/web-link-sdk`: `3.10.0 → 3.10.1`
- link's node-api dependency tightened `^2.0.25 → ^2.0.27` so consumers are guaranteed the patched node-api

> **Release ordering (post-merge):** dispatch **Deploy Node-API** first, confirm `2.0.27` is live on npm, *then* dispatch **Deploy Link**. Link `3.10.1` requires node-api `^2.0.27`, so publishing it before node-api is live would fail to resolve.

## Verification
- `yarn audit`: **38 → 8 moderate** (0 high / 0 low)
- `yarn build`: ✅ 3 projects · `yarn test`: ✅ 80/80

## Remaining 8 (risk exceptions — no in-major patch, not in this PR)
- **js-yaml**: v3 (`3.14.2` is the latest 3.x and still flagged); v4 has exact-pinned consumers. v3 consumers can't move to the `4.2.0` fix without a breaking major bump.
- **uuid**: only patched in `11.1.1`, but `jayson`/`@solana/web3.js` cap at `^8.3.2` (shipped Solana runtime path). Forcing v11 = semver violation with no test coverage.

Both are moderate, dev/build-toolchain transitives with no SDK-consumer runtime exposure → recommend a risk exception with @Frazer McCallum rather than a forced major bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRG-2584]: https://meshconnectapi.atlassian.net/browse/PRG-2584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ